### PR TITLE
maven install phase prevented if there are failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Requirements
 1.0.4
 -----
 * Added a checkbox to the report to optionally hide skipped steps
+* Substeps Mojos - Failures should prevent the Maven install phase from running; The runner mojo will throw a MojoFailureException only if the verify phase is not planned.  The Report Builder will throw any such exception if one is encountered in the maven session.
 
 
 1.0.3

--- a/api/src/main/java/org/substeps/report/IExecutionResultsCollector.java
+++ b/api/src/main/java/org/substeps/report/IExecutionResultsCollector.java
@@ -4,11 +4,12 @@ import com.technophobia.substeps.execution.node.RootNode;
 import com.technophobia.substeps.runner.IExecutionListener;
 
 import java.io.File;
+import java.io.Serializable;
 
 /**
  * Created by ian on 24/05/16.
  */
-public interface IExecutionResultsCollector extends IExecutionListener {
+public interface IExecutionResultsCollector extends IExecutionListener, Serializable {
     void initOutputDirectories(RootNode rootNode);
 
     void setDataDir(File dataDir);

--- a/core/src/main/scala/org/substeps/report/ExecutionResultsCollector.scala
+++ b/core/src/main/scala/org/substeps/report/ExecutionResultsCollector.scala
@@ -33,7 +33,7 @@ object ExecutionResultsCollector{
 
 
 // TODO - remove the ctor params to allow injection from Maven via setter... eurgh  builder instead ?  when to init ?
-class ExecutionResultsCollector extends  IExecutionResultsCollector{
+class ExecutionResultsCollector extends  IExecutionResultsCollector {
 
   private val log: Logger = LoggerFactory.getLogger(classOf[ExecutionResultsCollector])
 
@@ -49,8 +49,8 @@ class ExecutionResultsCollector extends  IExecutionResultsCollector{
   def setDataDir(dir : File) = this.dataDir = dir
   def setPretty(pretty : Boolean) = this.pretty = pretty
 
-
-  val UTF8 = Charset.forName("UTF-8")
+  @transient
+  lazy val UTF8 = Charset.forName("UTF-8")
 
   var featureToResultsDirMap: Map[FeatureNode, File] = Map()
 

--- a/runner/Maven/src/main/java/com/technophobia/substeps/runner/SubstepsReportBuilderMojo.java
+++ b/runner/Maven/src/main/java/com/technophobia/substeps/runner/SubstepsReportBuilderMojo.java
@@ -167,6 +167,26 @@ public class SubstepsReportBuilderMojo extends BaseSubstepsMojo {
 
         reportBuilder.buildFromDirectory(this.executionResultsCollector.getDataDir());
 
+
+
+        List<Throwable> exceptions = this.session.getResult().getExceptions();
+
+        if (exceptions != null && !exceptions.isEmpty()){
+            getLog().info("got exceptions");
+            for (Throwable t : exceptions){
+                if (t instanceof MojoFailureException){
+                    MojoFailureException failure = (MojoFailureException)t;
+                    // remove the exception otherwise it will get logged twice
+                    this.session.getResult().getExceptions().remove(t);
+
+                    throw failure;
+
+                }
+            }
+        }
+        else {
+            getLog().info("All good, no failures");
+        }
 //        ensureValidConfiguration();
 //
 //        this.runner = this.runTestsInForkedVM ? createForkedRunner() : createInProcessRunner();

--- a/runner/Maven/src/test/java/com/technophobia/substeps/mojo/runner/SubstepsRunnerMojoConfigTest.java
+++ b/runner/Maven/src/test/java/com/technophobia/substeps/mojo/runner/SubstepsRunnerMojoConfigTest.java
@@ -22,12 +22,22 @@ import com.technophobia.substeps.report.ExecutionReportBuilder;
 import com.technophobia.substeps.runner.ExecutionConfig;
 import com.technophobia.substeps.runner.SubstepsReportBuilderMojo;
 import com.technophobia.substeps.runner.SubstepsRunnerMojo;
+import org.apache.maven.artifact.repository.ArtifactRepository;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.execution.ReactorManager;
+import org.apache.maven.monitor.event.EventDispatcher;
 import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+import org.apache.maven.settings.Settings;
+import org.codehaus.plexus.PlexusContainer;
 import org.codehaus.plexus.configuration.PlexusConfiguration;
 import org.junit.Assert;
 import org.junit.Ignore;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
 
 import static org.hamcrest.Matchers.*;
 
@@ -42,14 +52,14 @@ public class SubstepsRunnerMojoConfigTest extends AbstractMojoTestCase {
     }
 
     private void actuallyRunTheTest() throws Exception{
-        File testPom = new File(getBasedir(),
-                "src/test/resources/sample-pom.xml");
+
+        File testPom = new File(getBasedir(), "src/test/resources/sample-pom.xml");
 
         Assert.assertNotNull(testPom);
         Assert.assertTrue(testPom.exists());
 
         PlexusConfiguration pluginConfiguration = this.extractPluginConfiguration("substeps-maven-plugin", testPom);
-        final SubstepsRunnerMojo mojo = (SubstepsRunnerMojo)lookupMojo("org.substeps", "substeps-maven-plugin", "1.0.2-SNAPSHOT", "run-features", pluginConfiguration);
+        final SubstepsRunnerMojo mojo = (SubstepsRunnerMojo)lookupMojo("org.substeps", "substeps-maven-plugin", "1.0.4-SNAPSHOT", "run-features", pluginConfiguration);
 
         Assert.assertNotNull("expecting a mojo", mojo);
 
@@ -103,9 +113,11 @@ public class SubstepsRunnerMojoConfigTest extends AbstractMojoTestCase {
 
     }
 
-    public void testMojoGoal() throws Exception {
+    public void testMojoConfig() throws Exception {
 
         // no op, can't get this test to work in release, when the version gets bumped
-
+        //actuallyRunTheTest();
     }
+
+
 }

--- a/runner/Maven/src/test/resources/sample-pom.xml
+++ b/runner/Maven/src/test/resources/sample-pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.substeps</groupId>
 	<artifactId>mojo-sample</artifactId>
-	<version>1.0.2-SNAPSHOT</version>
+	<version>1.0.4-SNAPSHOT</version>
 
 	<packaging>jar</packaging>
 	<name>pom sample</name>
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.substeps</groupId>
             <artifactId>substeps-core</artifactId>
-            <version>1.0.2-IM-SNAPSHOT</version>
+            <version>1.0.4-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -49,7 +49,9 @@
             <plugin>
                 <groupId>org.substeps</groupId>
                 <artifactId>substeps-maven-plugin</artifactId>
-                <version>1.0.2-SNAPSHOT</version>
+<!--
+                <version>1.0.4-SNAPSHOT</version>
+-->
 
                 <executions>
                     <execution>


### PR DESCRIPTION
Last release the running and reporting was split into two mojos with exceptions added to the MavenSession (session.getResult().addException(e) ) - this resulted in the maven install phase running when there are test failures.  This MR fixes that.  The runner mojo will stash the exception in the maven session if the goals include verify, install or deploy, the report mojo will then throw if an exception is found.   