### PR TITLE
Runtime evaluation of expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Requirements
 * Replaced Apache config with [Typesafe Config](https://github.com/typesafehub/config) - similar functionality but provides better nesting of properties, variable substitution
 * Added System property switch to use original properties files over new .conf files (`-Dsubsteps.use.dot.properties=true`)
 * Enable any parameters to be substituted with values from config - user ${config.expression}. Delimitters can be specified and Charset conversion too, see core-api reference.conf for details 
+* Enabled arguments to be evaluated at runtime against objects in the execution context
 
 1.0.3
 -----

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -67,12 +67,7 @@
             <groupId>velocity</groupId>
             <artifactId>velocity</artifactId>
             <version>1.5</version>
-            <!--<exclusions>-->
-                <!--<exclusion>-->
-                    <!--<groupId>commons-lang</groupId>-->
-                    <!--<artifactId>commons-lang</artifactId>-->
-                <!--</exclusion>-->
-            <!--</exclusions>-->
+
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -95,6 +90,12 @@
             <groupId>org.json4s</groupId>
             <artifactId>json4s-native_2.11</artifactId>
             <version>${json4s.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-jexl3</artifactId>
+            <version>3.0</version>
         </dependency>
 
         <!-- Test Dependencies -->

--- a/core/src/main/java/com/technophobia/substeps/model/ParentStep.java
+++ b/core/src/main/java/com/technophobia/substeps/model/ParentStep.java
@@ -74,7 +74,7 @@ public class ParentStep {
     public void initialiseParamValues(final Step step) {
         final HashMap<String, String> map = new HashMap<String, String>();
 
-        final String[] paramValues = Util.getArgs(this.parent.getPattern(),
+        final String[] paramValues = Arguments.getArgs(this.parent.getPattern(),
                 step.getLine(), null, Configuration.INSTANCE.getConfig());
 
         if (paramValues != null) {
@@ -97,7 +97,7 @@ public class ParentStep {
 
         log.debug("initialiseParamValues with line: " + line);
 
-        final String[] paramValues = Util.getArgs(this.parent.getPattern(),
+        final String[] paramValues = Arguments.getArgs(this.parent.getPattern(),
                 line, keywordPrecedence, Configuration.INSTANCE.getConfig());
 
         if (paramValues != null) {

--- a/core/src/main/java/com/technophobia/substeps/runner/builder/SubstepNodeBuilder.java
+++ b/core/src/main/java/com/technophobia/substeps/runner/builder/SubstepNodeBuilder.java
@@ -343,7 +343,7 @@ public class SubstepNodeBuilder {
         final String substitutedStepParam = substitutePlaceholders(stepParameter, parentArguments);
 
         stepNode.setLine(substitutedStepParam);
-        List<Object> argsList = Util.getArgs(stepImplementationPattern, substitutedStepParam, parameterTypes,
+        List<Object> argsList = Arguments.getArgs(stepImplementationPattern, substitutedStepParam, parameterTypes,
                 converterTypes);
 
         if (inlineTable != null) {

--- a/core/src/main/java/com/technophobia/substeps/runner/node/StepImplementationNodeRunner.java
+++ b/core/src/main/java/com/technophobia/substeps/runner/node/StepImplementationNodeRunner.java
@@ -67,6 +67,16 @@ public class StepImplementationNodeRunner extends AbstractNodeRunner<StepImpleme
                     }
                 }
                 evaluatedArgs = evaluatedArgsList.toArray();
+                node.setMethodArgs(evaluatedArgs);
+
+
+                SubSteps.Step stepAnnotation = node.getTargetMethod().getAnnotation(SubSteps.Step.class);
+                String rawSourceLine = stepAnnotation.value();
+
+                for (Object o : evaluatedArgsList){
+                    rawSourceLine = rawSourceLine.replaceFirst("\\([^\\)]*\\)", o.toString());
+                }
+                node.setLine(rawSourceLine);
             }
 
 

--- a/core/src/main/java/com/technophobia/substeps/runner/node/StepImplementationNodeRunner.java
+++ b/core/src/main/java/com/technophobia/substeps/runner/node/StepImplementationNodeRunner.java
@@ -20,13 +20,28 @@ package com.technophobia.substeps.runner.node;
 
 import com.technophobia.substeps.execution.node.RootNodeExecutionContext;
 import com.technophobia.substeps.execution.node.StepImplementationNode;
-import com.technophobia.substeps.model.Scope;
+import com.technophobia.substeps.model.*;
+import com.technophobia.substeps.model.parameter.Converter;
+import com.technophobia.substeps.runner.ExecutionNodeRunner;
 import com.technophobia.substeps.runner.ProvidesScreenshot;
 import com.technophobia.substeps.runner.SubstepExecutionFailure;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class StepImplementationNodeRunner extends AbstractNodeRunner<StepImplementationNode, Void> {
+
+    private static final Logger log = LoggerFactory.getLogger(StepImplementationNodeRunner.class);
+
+
 
     @Override
     protected boolean execute(StepImplementationNode node, RootNodeExecutionContext context) {
@@ -35,8 +50,28 @@ public class StepImplementationNodeRunner extends AbstractNodeRunner<StepImpleme
 
         try {
 
+            // run through any args - if there's any expressions in there, evaluate them now
+            Object[] evaluatedArgs = null;
+
+            if (node.getMethodArgs() != null && node.getMethodArgs().length > 0) {
+                List<Object> evaluatedArgsList = new ArrayList<>();
+                for (Object o : node.getMethodArgs()) {
+
+                    if (o instanceof String) {
+
+                        Object result = Arguments.evaluateExpression((String) o);
+                        evaluatedArgsList.add(result);
+
+                    } else {
+                        evaluatedArgsList.add(o);
+                    }
+                }
+                evaluatedArgs = evaluatedArgsList.toArray();
+            }
+
+
             context.getMethodExecutor().executeMethod(node.getTargetClass(), node.getTargetMethod(),
-                    node.getMethodArgs());
+                    evaluatedArgs);
             context.setTestsHaveRun();
             success = true;
 

--- a/core/src/main/scala/org/substeps/report/ExecutionResultsCollector.scala
+++ b/core/src/main/scala/org/substeps/report/ExecutionResultsCollector.scala
@@ -32,7 +32,8 @@ object ExecutionResultsCollector{
 }
 
 
-class ExecutionResultsCollector extends  IExecutionResultsCollector {
+class
+ExecutionResultsCollector extends  IExecutionResultsCollector {
 
   @transient
   private lazy val log: Logger = LoggerFactory.getLogger(classOf[ExecutionResultsCollector])

--- a/core/src/test/java/com/technophobia/substeps/runner/ExecutionNodeRunnerTest.java
+++ b/core/src/test/java/com/technophobia/substeps/runner/ExecutionNodeRunnerTest.java
@@ -24,7 +24,7 @@ import com.technophobia.substeps.execution.ExecutionResult;
 import com.technophobia.substeps.execution.Feature;
 import com.technophobia.substeps.execution.ImplementationCache;
 import com.technophobia.substeps.execution.node.*;
-import com.technophobia.substeps.model.Util;
+import com.technophobia.substeps.model.Arguments;
 import com.technophobia.substeps.model.exception.SubstepsConfigurationException;
 import com.technophobia.substeps.model.exception.UnimplementedStepException;
 import com.technophobia.substeps.runner.setupteardown.Annotations.BeforeAllFeatures;
@@ -713,10 +713,10 @@ public class ExecutionNodeRunnerTest {
 
         final String patternString = "Given a substep that takes one parameter \"([^\"]*)\"";
         final String[] keywordPrecedence = new String[]{"Given", "And"};
-        String[] args1 = Util.getArgs(patternString, srcString1, keywordPrecedence, cfg);
+        String[] args1 = Arguments.getArgs(patternString, srcString1, keywordPrecedence, cfg);
 
 
-        String[] args2 = Util.getArgs(patternString, srcString2, keywordPrecedence, cfg);
+        String[] args2 = Arguments.getArgs(patternString, srcString2, keywordPrecedence, cfg);
 
         Assert.assertNotNull(args2);
         Assert.assertThat(args2[0], is("src2"));
@@ -724,7 +724,7 @@ public class ExecutionNodeRunnerTest {
         Assert.assertNotNull(args1);
         Assert.assertThat(args1[0], is("src1"));
 
-        String[] args3 = Util.getArgs(patternString, srcString3, keywordPrecedence, cfg);
+        String[] args3 = Arguments.getArgs(patternString, srcString3, keywordPrecedence, cfg);
         Assert.assertNotNull(args3);
         Assert.assertThat(args3[0], is("bob"));
 

--- a/core/src/test/java/com/technophobia/substeps/runner/ParsingTests.java
+++ b/core/src/test/java/com/technophobia/substeps/runner/ParsingTests.java
@@ -20,6 +20,7 @@
 package com.technophobia.substeps.runner;
 
 import com.technophobia.substeps.model.ParentStep;
+import com.technophobia.substeps.model.Scope;
 import com.technophobia.substeps.model.Step;
 import org.junit.Assert;
 import org.junit.Test;
@@ -36,6 +37,8 @@ import static org.hamcrest.CoreMatchers.is;
  * @author ian
  */
 public class ParsingTests {
+
+
     @Test
     public void testRegEx() {
         final String stepParameter = "bob <start_locateButton>";
@@ -199,7 +202,7 @@ public class ParsingTests {
         final ParentStep parentStep = new ParentStep(aParentSubStep);
 
         parentStep.initialiseParamValues(topLevelStepReDefinedInSubSteps);
-        // String[] paramValues = Util.getArgs(this.parent.pattern, step.param);
+        // String[] paramValues = Arguments.getArgs(this.parent.pattern, step.param);
 
         final Map<String, String> paramValueMap = parentStep.getParamValueMap().getParameters();
         Assert.assertNotNull(paramValueMap);

--- a/core/src/test/scala/com/technophobia/substeps/model/ArgumentsTest.scala
+++ b/core/src/test/scala/com/technophobia/substeps/model/ArgumentsTest.scala
@@ -1,0 +1,35 @@
+package com.technophobia.substeps.model
+
+import com.technophobia.substeps.runner.ExecutionContext
+import org.scalatest.{FunSuite, Matchers}
+
+/**
+  * Created by ian on 13/01/17.
+  */
+class Sample(name : String, other : Other){
+  def getName() = name
+  def getOther() = other
+}
+
+class Other(name : String){
+  def getName() = name
+}
+
+class ArgumentsTest extends FunSuite with Matchers{
+
+  test("test Arguments expression evaluation"){
+    val res1 = Arguments.evaluateExpression("${doesnt.exist}")
+    res1 should be (null)
+
+    ExecutionContext.put(Scope.SUITE, "key", new Sample("suite", new Other("o1")))
+
+    ExecutionContext.put(Scope.SCENARIO, "key", new Sample("scenario", new Other("o2")))
+
+    val res2 = Arguments.evaluateExpression("${key.name}")
+    res2 should be ("scenario")
+
+    val res3 = Arguments.evaluateExpression("${key.other.name}")
+    res3 should be ("o2")
+
+  }
+}

--- a/core/src/test/scala/org/substeps/runner/ExpressionEvaluationTest.scala
+++ b/core/src/test/scala/org/substeps/runner/ExpressionEvaluationTest.scala
@@ -1,0 +1,148 @@
+package org.substeps.runner
+
+import java.io.File
+
+import com.technophobia.substeps.execution.ImplementationCache
+import com.technophobia.substeps.model.SubSteps.StepImplementations
+import com.technophobia.substeps.model._
+import com.technophobia.substeps.runner._
+import com.technophobia.substeps.runner.builder.ExecutionNodeTreeBuilder
+import com.technophobia.substeps.runner.setupteardown.SetupAndTearDown
+import com.technophobia.substeps.runner.syntax.SyntaxBuilder
+import org.scalatest.{FlatSpec, ShouldMatchers}
+import org.slf4j.LoggerFactory
+import org.substeps.report.ExecutionResultsCollector
+
+import scala.collection.JavaConverters._
+
+
+/**
+  * Created by ian on 13/01/17.
+  */
+class ExpressionEvaluationTest extends FlatSpec with ShouldMatchers with FeatureFilesFromSource{
+
+  private val log = LoggerFactory.getLogger(classOf[ParsingFromSourceTests])
+
+
+  "step execution" must "evaluate expressions" in {
+
+    val simpleFeature =
+      """
+        | Feature: a simple feature
+        | Scenario: config and runtime expression scenario
+        |   A step with a value from config "${users.default.name}"
+        |   SetupContext
+        |   A step with param from context "${key.other.name}"
+        |
+      """.stripMargin
+
+
+    class Sample(name : String, other : Other){
+      def getName() = name
+      def getOther() = other
+    }
+
+    class Other(name : String){
+      def getName() = name
+    }
+
+    @StepImplementations
+    class StepImpls (){
+
+      @SubSteps.Step("""A step with a value from config "([^"]*)"""")
+      def stepPassedFromConfig(arg : String) = log.debug("stepPassedFromConfig: " + arg)
+
+      @SubSteps.Step("SetupContext")
+      def setupContext() = {
+        ExecutionContext.put(Scope.SCENARIO, "key", new Sample("scenario", new Other("fromContext")))
+
+        log.debug("SetupContext")
+      }
+
+      @SubSteps.Step("""A step with param from context "([^"]*)"""")
+      def stepPassedFromContext(arg: String) = log.debug("stepPassedFromContext: " + arg)
+    }
+
+    val featureFile = createFeatureFile(simpleFeature, "expression-evaluation.feature")
+
+    val stepImplementationClasses : List[java.lang.Class[_]] = List(classOf[StepImpls])
+
+    val executionConfig = new SubstepsExecutionConfig
+
+    executionConfig.setStepImplementationClasses(stepImplementationClasses.asJava)
+
+    val syntax: Syntax = SyntaxBuilder.buildSyntax(stepImplementationClasses.asJava, new PatternMap[ParentStep]())
+
+    val parameters: TestParameters = new TestParameters(new TagManager(""), syntax, List(featureFile).asJava)
+
+    val cfgWrapper = new ExecutionConfigWrapper(executionConfig)
+    val nodeTreeBuilder: ExecutionNodeTreeBuilder = new ExecutionNodeTreeBuilder(parameters, cfgWrapper)
+
+    // building the tree can throw critical failures if exceptions are found
+    val rootNode = nodeTreeBuilder.buildExecutionNodeTree("test description")
+
+    log.debug("rootNode 1:\n" + rootNode.toDebugString)
+
+    val executionCollector = new ExecutionResultsCollector
+    val dataDir = ExecutionResultsCollector.getBaseDir(new File("target"))
+    executionCollector.setDataDir(dataDir)
+    executionCollector.setPretty(true)
+
+    executionConfig.setDataOutputDirectory(dataDir)
+
+    val runner = new ExecutionNodeRunner()
+
+
+    runner.addNotifier(executionCollector)
+
+    val methodExecutorToUse = new ImplementationCache()
+
+    val setupAndTearDown: SetupAndTearDown = new SetupAndTearDown(executionConfig.getInitialisationClasses, methodExecutorToUse)
+
+
+    val rootNode2 = runner.prepareExecutionConfig(new ExecutionConfigWrapper(executionConfig), syntax, parameters, setupAndTearDown, methodExecutorToUse, null)
+
+    executionCollector.initOutputDirectories(rootNode2)
+
+    log.debug("rootNode 2:\n" + rootNode2.toDebugString)
+
+    val finalRootNode = runner.run()
+
+    log.debug("finalRootNode:\n" + finalRootNode.toDebugString)
+
+    //    // what are we expecting now:
+    //    //    val rootDir = executionCollector.getRootReportsDir
+    //    dataDir.exists() should be (true)
+    //
+    //    val featureDirs = dataDir.listFiles().toList.filter(f => f.isDirectory)
+    //
+    //    featureDirs.size should be (2)
+    //
+    //    for (fDir <- featureDirs){
+    //
+    //      if (fDir.getName.contains("simple")){
+    //
+    //        validateSimpleFeatureResults(fDir)
+    //
+    //      } else if (fDir.getName.contains("outline")){
+    //
+    //
+    //        val scenarioResults = fDir.listFiles()
+    //
+    //        scenarioResults.length should be (5)
+    //
+    //      } else {
+    //        Assert.fail("unexpected sub dir")
+    //      }
+    //
+    //    }
+    //
+    //    val resultSummaryFile = dataDir.listFiles().toList.filter(f => f.isFile)
+    //
+    //    resultSummaryFile.size should be (1)
+
+
+  }
+
+
+}

--- a/core/src/test/scala/org/substeps/runner/ExpressionEvaluationTest.scala
+++ b/core/src/test/scala/org/substeps/runner/ExpressionEvaluationTest.scala
@@ -30,9 +30,9 @@ class ExpressionEvaluationTest extends FlatSpec with ShouldMatchers with Feature
       """
         | Feature: a simple feature
         | Scenario: config and runtime expression scenario
-        |   A step with a value from config "${users.default.name}"
+        |   A step with a value from config "${users.default.name}" and one "hardcoded"
         |   SetupContext
-        |   A step with param from context "${key.other.name}"
+        |   A step with a "hardcoded" param and another from context "${key.other.name}"
         |
       """.stripMargin
 
@@ -49,8 +49,8 @@ class ExpressionEvaluationTest extends FlatSpec with ShouldMatchers with Feature
     @StepImplementations
     class StepImpls (){
 
-      @SubSteps.Step("""A step with a value from config "([^"]*)"""")
-      def stepPassedFromConfig(arg : String) = log.debug("stepPassedFromConfig: " + arg)
+      @SubSteps.Step("""A step with a value from config "([^"]*)" and one "([^"]*)"""")
+      def stepPassedFromConfig(arg : String, arg2: String) = log.debug("stepPassedFromConfig: " + arg)
 
       @SubSteps.Step("SetupContext")
       def setupContext() = {
@@ -59,8 +59,8 @@ class ExpressionEvaluationTest extends FlatSpec with ShouldMatchers with Feature
         log.debug("SetupContext")
       }
 
-      @SubSteps.Step("""A step with param from context "([^"]*)"""")
-      def stepPassedFromContext(arg: String) = log.debug("stepPassedFromContext: " + arg)
+      @SubSteps.Step("""A step with a "([^"]*)" param and another from context "([^"]*)"""")
+      def stepPassedFromContext(arg : String, arg2: String) = log.debug("stepPassedFromContext: " + arg2)
     }
 
     val featureFile = createFeatureFile(simpleFeature, "expression-evaluation.feature")

--- a/core/src/test/scala/org/substeps/runner/ParsingFromSourceTests.scala
+++ b/core/src/test/scala/org/substeps/runner/ParsingFromSourceTests.scala
@@ -6,36 +6,41 @@ import java.nio.charset.Charset
 import com.google.common.io.Files
 import com.technophobia.substeps.execution.node.{ExecutionNode, IExecutionNode}
 import com.technophobia.substeps.execution.{ExecutionResult, ImplementationCache}
-import com.technophobia.substeps.model._
 import com.technophobia.substeps.model.SubSteps.StepImplementations
+import com.technophobia.substeps.model._
 import com.technophobia.substeps.parser.FileContents
-import com.technophobia.substeps.report.DefaultExecutionReportBuilder
-import com.technophobia.substeps.runner.builder.ExecutionNodeTreeBuilder
 import com.technophobia.substeps.runner._
+import com.technophobia.substeps.runner.builder.ExecutionNodeTreeBuilder
 import com.technophobia.substeps.runner.setupteardown.SetupAndTearDown
 import com.technophobia.substeps.runner.syntax._
-import com.technophobia.substeps.steps.TestStepImplementations
 import org.hamcrest.Matchers._
 import org.json4s.NoTypeHints
 import org.json4s.native.Serialization
+import org.json4s.native.Serialization.read
 import org.junit.Assert
 import org.scalatest._
+import org.slf4j.LoggerFactory
 import org.substeps.report.{ExecutionResultsCollector, NodeDetail}
 
 import scala.collection.JavaConverters._
-import scala.collection.JavaConverters._
-import org.json4s._
-import org.json4s.native.Serialization
-import org.json4s.native.Serialization.{read, write}
-import org.slf4j.{Logger, LoggerFactory}
 
-import scala.collection.JavaConversions._
-import scala.collection.JavaConverters._
+trait FeatureFilesFromSource {
+
+  def createFeatureFile(content: String, featureFileName: String): FeatureFile = {
+    val featureFileContentsFromSource = new FileContents(content.split("\n").toList.asJava, new File(featureFileName))
+
+    val parser: FeatureFileParser = new FeatureFileParser
+
+    val featureFile: FeatureFile = parser.getFeatureFile(featureFileContentsFromSource)
+    featureFile
+  }
+
+}
 
 /**
   * Created by ian on 20/05/16.
   */
-class ParsingFromSourceTests extends FlatSpec with ShouldMatchers {
+class ParsingFromSourceTests extends FlatSpec with ShouldMatchers with FeatureFilesFromSource {
 
   val UTF8 = Charset.forName("UTF-8")
 
@@ -214,14 +219,6 @@ Scenario: inline table
     // TODO more assertions here
   }
 
-  def createFeatureFile(content: String, featureFileName: String): FeatureFile = {
-    val featureFileContentsFromSource = new FileContents(content.split("\n").toList.asJava, new File(featureFileName))
-
-    val parser: FeatureFileParser = new FeatureFileParser
-
-    val featureFile: FeatureFile = parser.getFeatureFile(featureFileContentsFromSource)
-    featureFile
-  }
 
   "running some failing features marked as non critical" must "not fail the build and be visible" in {
 


### PR DESCRIPTION
Enable an expression to be supplied as a parameter to a substep or stepimpl that is evaluated at runtime.  The expression is evaluated against the ExecutionContext, searching the scopes from Step to Suite. see ExpressionEvaluationTest for an example