### PR TITLE
escape glossary data, corrected screenshot path

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Requirements
 * Made the report builder more robust when there are no tests run
 * Modified the Substeps exceptions to limit the stack trace
 * Improved error message when no tests are run
+* escaped < and > in the glossary data
+* Corrected the path to the screenshot images to be relative so that they work when served off a server and locally.
 
 1.0.5
 -----

--- a/core/src/main/scala/org/substeps/report/ReportBuilder.scala
+++ b/core/src/main/scala/org/substeps/report/ReportBuilder.scala
@@ -96,7 +96,11 @@ class ReportBuilder extends IReportBuilder with ReportFrameTemplate with UsageTr
 
     val glossaryElements =
       data.map(sid => sid.expressions.map(sd => {
-        GlossaryElement(sd.section, sd.expression, sid.className, sd.regex, sd.example, sd.description, sd.parameterNames, sd.parameterClassNames)
+
+        val escapedExpression =
+          sd.expression.replaceAll("\\$$", "").replaceAll("<", "&lt;").replaceAll(">", "&gt;")
+
+        GlossaryElement(sd.section, escapedExpression, sid.className, sd.regex, sd.example, sd.description, sd.parameterNames, sd.parameterClassNames)
       })).flatten
 
     glossaryElements
@@ -748,7 +752,7 @@ class ReportBuilder extends IReportBuilder with ReportFrameTemplate with UsageTr
     nodeDetail.exceptionMessage.map(s => writer.append(s""""emessage":"${StringEscapeUtils.escapeEcmaScript(s)}",""") )
 
 
-    nodeDetail.screenshot.map(s => writer.append(s"""screenshot:"${dataDir + s}",""") )
+    nodeDetail.screenshot.map(s => writer.append(s"""screenshot:"data${s}",""") )
     nodeDetail.stackTrace.map(s => writer.append(s"""stacktrace:[${s.mkString("\"", "\",\n\"", "\"")}],"""))
 
     writer.append(s""""children":[""")

--- a/core/src/test/java/com/technophobia/substeps/runner/ExecutionNodeRunnerTest.java
+++ b/core/src/test/java/com/technophobia/substeps/runner/ExecutionNodeRunnerTest.java
@@ -846,17 +846,6 @@ public class ExecutionNodeRunnerTest {
         Assert.assertThat(rootNode.getChildren().get(0).getChildren().size(), is(1));
     }
 
-    private static final Logger log = LoggerFactory.getLogger(ExecutionNodeRunnerTest.class);
-
-
-    @Test
-    public void testNoTestRunException(){
-
-        Throwable e = new NoTestsRunException();
-
-        log.debug("an exception: ", e);
-    }
-
 }
 
 


### PR DESCRIPTION
fixes for gloassary data escaping #40 and #41 report screenshot relative paths 